### PR TITLE
0.3.0 - Reaction Tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 - Add User Color to Message Header
 
+## 0.3.0
+- **Added**
+  - `Reaction Tracker`
+    - This has 2 features:
+      - When a reaction is used, it creates an effect marking a character has used a reaction, or if they have already used a reaction in the last round, increments a counter showing the total number of reactions used (to helpfully track characters with multiple reactions)
+      - When combat starts you gain the Reaction Used effect until your turn starts [in line with RAW](https://2e.aonprd.com/Rules.aspx?ID=2432&Redirected=1)
+    - Note: this feature requires the GM to be active to work
+
 ## 0.2.0
 
 - **Added**

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ You can access the changelog [here](/CHANGELOG.md).
 
 - **Notify**
   - Notify when you have recharged your `spellstrike`
+- **Track**
+  - `Reaction Tracker`
+    - This has 2 features:
+      - When a reaction is used, it creates an effect marking a character has used a reaction, or if they have already used a reaction in the last round, increments a counter showing the total number of reactions used (to helpfully track characters with multiple reactions)
+      - When combat starts you gain the Reaction Used effect until your turn starts [in line with RAW](https://2e.aonprd.com/Rules.aspx?ID=2432&Redirected=1)
+    - Note: this feature requires the GM to be active to work
 
 ## Contributors
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -55,18 +55,31 @@
           "recharge": {
             "name": "[Notify] Spellstrike Recharge",
             "hint": "Adds a little ui notification when your spellstrike should be recharged"
-          } 
+          }
+        }
+      },
+      "track": {
+        "reactions": {
+          "name": "[Track] Reactions",
+          "hint": "This feature creates (and increments) an effect on a token that counts if a token has used a reaction. To note it also applies this effect to every token as combat starts"
         }
       }
     },
     "notification": {
       "spellstrike": {
-          "recharged": "Spellstrike Recharged",
-          "conflux": "You just cast a conflux spell which allows you to recharge your spellstrike.",
-          "feature": "You used a feature that recharges your spellstrike",
-          "on-success": "You used a feature that recharges your spellstrike if you succeeded on a roll",
-          "other-option": "Alternatively you can always spend 1 action to recharge, this action has the <b>concentrate</b> trait"
+        "recharged": "Spellstrike Recharged",
+        "conflux": "You just cast a conflux spell which allows you to recharge your spellstrike.",
+        "feature": "You used a feature that recharges your spellstrike",
+        "on-success": "You used a feature that recharges your spellstrike if you succeeded on a roll",
+        "other-option": "Alternatively you can always spend 1 action to recharge, this action has the <b>concentrate</b> trait"
       }
-  }
+    }
+  },
+  "items": {
+    "effects": {
+      "reaction-used": {
+        "name": "Effect: Reaction Used"
+      }
+    }
   }
 }

--- a/scripts/lib/reactionTracker.js
+++ b/scripts/lib/reactionTracker.js
@@ -1,0 +1,93 @@
+export function setupReactionTracker(active = true) {
+    if (game.user.isGM) {
+        if (active) {
+            Hooks.on("combatStart", startOfCombatReactions)
+            Hooks.on("createChatMessage", usedReaction)
+            Hooks.on("deleteCombat", removeEncounterReactions);
+        } else {
+            Hooks.off("combatStart", startOfCombatReactions)
+            Hooks.off("createChatMessage", usedReaction)
+            Hooks.off("deleteCombat", removeEncounterReactions);
+        }
+    }
+}
+
+async function startOfCombatReactions(encounter) {
+    reactionUsed(encounter?.combatants?.contents?.map(combatant => combatant.actor), true);
+}
+
+async function usedReaction(message) {
+    if (
+        message?.item?.system?.actionType?.value === "reaction" &&
+        !message?.flags?.pf2e?.context?.type &&
+        message.actor) {
+        reactionUsed([message.actor], false)
+    }
+}
+
+async function removeEncounterReactions(encounter) {
+    const actors = encounter?.combatants?.contents?.map(combatant => combatant.actor);
+    for (const actor of actors) {
+        const existing = actor.itemTypes.effect.find(
+            (e) => e.slug === "effect-reaction-used"
+        );
+        existing.delete();
+    }
+}
+
+
+async function reactionUsed(actors, combatStart) {
+    if (actors.length === 0) return;
+
+    const item = REACTION_USED_EFFECT(combatStart);
+
+    for (const actor of actors) {
+        const existing = actor.itemTypes.effect.find(
+            (e) => e.slug === "effect-reaction-used"
+        );
+        if (existing) {
+            actor.updateEmbeddedDocuments("Item", [
+                {
+                    _id: existing.id,
+                    "system.badge.value": existing.system.badge.value + 1,
+                },
+            ]);
+        } else {
+            const tempItem = foundry.utils.deepClone(item)
+            tempItem.system = {
+                ...item.system,
+                context: {
+                    origin: {
+                        actor: actor.uuid,
+                        token: actor?.getActiveTokens()?.[0]?.document?.uuid
+                    }
+                }
+            }
+            actor.createEmbeddedDocuments("Item", [tempItem]);
+        }
+    }
+}
+
+const REACTION_USED_EFFECT = (combatStart) => ({
+    name: game.i18n.has("sundry.items.effects.reaction-used.name")
+        ? game.i18n.localize("sundry.items.effects.reaction-used.name")
+        : "Effect: Reaction Used",
+    img: "systems/pf2e/icons/actions/Reaction.webp",
+    type: "effect",
+    system: {
+        badge: {
+            type: "counter",
+            value: 1,
+        },
+        duration: {
+            value: combatStart ? 0 : 1,
+            unit: "rounds",
+            expiry: "turn-start",
+            sustained: false,
+        },
+        publication: {
+            title: "PF2e Sundry",
+        },
+        slug: "effect-reaction-used",
+    },
+});

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -5,6 +5,7 @@ import { hideDefaultCraftChecks, hideSellAllTreasure } from "./lib/sheetTweaks.j
 import { setupColorizeToolbeltMessageSaves, setupHighlightToolbeltRollSaves } from "./lib/pf2eToolbelt.js";
 import { setupColorizePersistentPF2eHUD } from "./lib/pf2eHUD.js";
 import { setupNotifySpellstrikeRecharge } from "./lib/notify.js";
+import { setupReactionTracker } from "./lib/reactionTracker.js";
 
 export const MODULE_ID = 'sundry';
 
@@ -42,6 +43,10 @@ Hooks.once('ready', async function () {
 
     setupNotifySpellstrikeRecharge(
         getSetting('notify.spellstrike.recharge')
+    )
+
+    setupReactionTracker(
+        getSetting('track.reactions')
     )
 
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,6 +1,7 @@
 import { setupNotifySpellstrikeRecharge } from "./lib/notify.js";
 import { setupColorizePersistentPF2eHUD } from "./lib/pf2eHUD.js";
 import { setupColorizeToolbeltMessageSaves, setupHighlightToolbeltRollSaves } from "./lib/pf2eToolbelt.js";
+import { setupReactionTracker } from "./lib/reactionTracker.js";
 import { hideDefaultCraftChecks, hideSellAllTreasure } from "./lib/sheetTweaks.js";
 import { minifySimpleRequests } from "./lib/simpleRequests.js";
 import { MODULE_ID } from "./module.js";
@@ -10,7 +11,7 @@ export function setupSettings() {
         name: `${MODULE_ID}.module-settings.colorize.pf2e-hud.persistent.name`,
         hint: `${MODULE_ID}.module-settings.colorize.pf2e-hud.persistent.hint`,
         scope: "world",
-        config: true,
+        config: game.system.id === 'pf2e',
         default: false,
         type: Boolean,
         onChange: value => {
@@ -22,7 +23,7 @@ export function setupSettings() {
         name: `${MODULE_ID}.module-settings.colorize.pf2e-toolbelt.target-helper.roll.name`,
         hint: `${MODULE_ID}.module-settings.colorize.pf2e-toolbelt.target-helper.roll.hint`,
         scope: "world",
-        config: true,
+        config: game.system.id === 'pf2e',
         default: false,
         type: Boolean,
         onChange: value => {
@@ -34,7 +35,7 @@ export function setupSettings() {
         name: `${MODULE_ID}.module-settings.hide.default-craft-checks.name`,
         hint: `${MODULE_ID}.module-settings.hide.default-craft-checks.hint`,
         scope: "world",
-        config: true,
+        config: game.system.id === 'pf2e',
         default: false,
         type: Boolean,
         onChange: value => {
@@ -46,7 +47,7 @@ export function setupSettings() {
         name: `${MODULE_ID}.module-settings.hide.sell-all-treasure.name`,
         hint: `${MODULE_ID}.module-settings.hide.sell-all-treasure.hint`,
         scope: "world",
-        config: true,
+        config: game.system.id === 'pf2e',
         default: false,
         type: Boolean,
         onChange: value => {
@@ -58,7 +59,7 @@ export function setupSettings() {
         name: `${MODULE_ID}.module-settings.highlight.pf2e-toolbelt.target-helper.roll.name`,
         hint: `${MODULE_ID}.module-settings.highlight.pf2e-toolbelt.target-helper.roll.hint`,
         scope: "world",
-        config: true,
+        config: game.system.id === 'pf2e',
         default: false,
         type: Boolean,
         onChange: value => {
@@ -93,11 +94,23 @@ export function setupSettings() {
         name: `${MODULE_ID}.module-settings.notify.spellstrike.recharge.name`,
         hint: `${MODULE_ID}.module-settings.notify.spellstrike.recharge.hint`,
         scope: "world",
-        config: true,
+        config: game.system.id === 'pf2e',
         default: false,
         type: Boolean,
         onChange: value => {
             setupNotifySpellstrikeRecharge(value)
+        }
+    });
+
+    game.settings.register(MODULE_ID, "track.reactions", {
+        name: `${MODULE_ID}.module-settings.track.reactions.name`,
+        hint: `${MODULE_ID}.module-settings.track.reactions.hint`,
+        scope: "world",
+        config: game.system.id === 'pf2e',
+        default: false,
+        type: Boolean,
+        onChange: value => {
+            setupReactionTracker(value)
         }
     });
 }


### PR DESCRIPTION
- **Added**
  - `Reaction Tracker`
    - This has 2 features:
      - When a reaction is used, it creates an effect marking a character has used a reaction, or if they have already used a reaction in the last round, increments a counter showing the total number of reactions used (to helpfully track characters with multiple reactions)
      - When combat starts you gain the Reaction Used effect until your turn starts [in line with RAW](https://2e.aonprd.com/Rules.aspx?ID=2432&Redirected=1)
    - Note: this feature requires the GM to be active to work