### PR TITLE
0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - Add User Color to Message Header
 
+## 0.7.0
+
+- **Added**
+  - `Character Campaign Notes`
+    - Adds a new hotkey (Default `N`) to open an editable dialog of their assigned character's `Campaign Notes` field on their character sheet for quick access
+
 ## 0.6.0
 
 - **Added**

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ You can access the changelog [here](/CHANGELOG.md).
 
   ![highlight-save](https://github.com/user-attachments/assets/0f8e1237-da4a-4e1f-947e-df5e94294bf3)
 
+- **Hotkey**
+
+  - `Character Campaign Notes` - Adds a new hotkey (Default `N`) to open an editable dialog of their assigned character's `Campaign Notes` field on their character sheet for quick access
+
 - **Minify**
 
   - `Simple Requests` module to minify the chat area it takes up

--- a/languages/en.json
+++ b/languages/en.json
@@ -88,6 +88,12 @@
         }
       }
     },
+    "controls": {
+      "player-notes": {
+        "name": "Open Character 'Campaign Notes'",
+        "description": "Opens an editable version of the player's assigned character's 'Campaign Notes' section of their character sheet"
+      }
+    },
     "notification": {
       "spellstrike": {
         "recharged": "Spellstrike Recharged",
@@ -95,10 +101,16 @@
         "feature": "You used a feature that recharges your spellstrike",
         "on-success": "You used a feature that recharges your spellstrike if you succeeded on a roll",
         "other-option": "Alternatively you can always spend 1 action to recharge, this action has the <b>concentrate</b> trait"
+      },
+      "player-notes": {
+        "updated": "Campaign Notes Updated!"
       }
     },
     "display": {
-      "base-damage": "Base Damage"
+      "base-damage": "Base Damage",
+      "player-notes": {
+        "title": "Campaign Notes Editor"
+      }
     },
     "items": {
       "effects": {

--- a/scripts/lib/openNotes.js
+++ b/scripts/lib/openNotes.js
@@ -1,0 +1,54 @@
+export async function openPlayerNotes({ open, edit }) {
+    const actor = game.user?.character;
+    if (!actor) return;
+    const noteInfo = actor?.system?.details?.biography.campaignNotes;
+
+    // Create dialog with ProseMirror editor
+    const display = await TextEditor.enrichHTML(noteInfo);
+    const content = `
+        <prose-mirror
+            name="biography"
+            value="${noteInfo}"
+            style="height: 390px">
+                ${display}
+        </prose-mirror>
+    `;
+
+    const dialog = await foundry.applications.api.DialogV2.wait({
+        window: {
+            title: game.i18n.localize(`${MODULE_ID}.display.player-notes.title`)
+        },
+        content,
+        position: {
+            width: 750,
+            height: 500
+        },
+        buttons: [
+            {
+                label: "Save",
+                action: "save",
+                icon: "fas fa-save",
+                default: true,
+                callback: (event, button, dialog) => {
+                    return button.form.elements.biography.value;
+                }
+            },
+            {
+                label: "Cancel",
+                action: "cancel",
+                icon: "fas fa-times"
+            }
+        ]
+    });
+
+    // If user clicked Save, update the actor
+    if (dialog !== "cancel") {
+        await actor.update({
+            "system.details.biography.campaignNotes": dialog
+        });
+
+        ui.notifications.info(
+            game.i18n.localize(`${MODULE_ID}.notification.player-notes.updated`)
+        );
+    }
+}

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,6 +1,6 @@
 import { getSetting } from "./lib/helpers.js";
 import { minifySimpleRequests } from "./lib/simpleRequests.js";
-import { loadAllTemplates, setupSettings } from "./settings.js";
+import { loadAllTemplates, registerKeybindings, setupSettings } from "./settings.js";
 import { hideDefaultCraftChecks, hideSellAllTreasure } from "./lib/sheetTweaks.js";
 import { setupColorizeToolbeltMessageSaves, setupHighlightToolbeltRollSaves } from "./lib/pf2eToolbelt.js";
 import { setupColorizePersistentPF2eHUD } from "./lib/pf2eHUD.js";
@@ -14,6 +14,7 @@ export const MODULE_ID = 'sundry';
 
 Hooks.once('init', async function () {
     setupSettings();
+    registerKeybindings();
     loadAllTemplates();
 });
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -2,6 +2,7 @@ import { TEMPLATES } from "./lib/const.js";
 import { setupHideHeaderButtonText } from "./lib/hideHeaderButtonText.js";
 import { setupDisplayItemPropertyRunes } from "./lib/itemPropertyRunes.js";
 import { setupNotifySpellstrikeRecharge } from "./lib/notify.js";
+import { openPlayerNotes } from "./lib/openNotes.js";
 import { setupColorizePersistentPF2eHUD } from "./lib/pf2eHUD.js";
 import { setupColorizeToolbeltMessageSaves, setupHighlightToolbeltRollSaves } from "./lib/pf2eToolbelt.js";
 import { setupReactionTracker } from "./lib/reactionTracker.js";
@@ -168,6 +169,30 @@ export function setupSettings() {
             "off": `${MODULE_ID}.module-settings.track.reaction-usage.choices.off`
         }
     });
+}
+
+export function registerKeybindings() {
+    game.keybindings.register(MODULE_ID, "player-notes", {
+      name: game.i18n.localize(`${MODULE_ID}.controls.player-notes.name`),
+      hint: game.i18n.localize(`${MODULE_ID}.controls.player-notes.hint`),
+      editable: [
+        {
+          key: "KeyN",
+        },
+      ],
+      onDown: (context) => {
+        if (context.isShift) {
+        //   game.objection.api.objection({ type: "objection", flipped: true });
+        } else {
+            openPlayerNotes({open: true, edit: true});
+        }
+      },
+      onUp: () => {},
+      restricted: false, // Restrict this Keybinding to gamemaster only?
+    //   reservedModifiers: ["Shift"], // On ALT, the notification is permanent instead of temporary
+      precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL,
+    });
+
 }
 
 export function loadAllTemplates() {


### PR DESCRIPTION
- **Added**
  - `Character Campaign Notes`
    - Adds a new hotkey (Default `N`) to open an editable dialog of their assigned character's `Campaign Notes` field on their character sheet for quick access