### PR TITLE
Fix to error when "start of session checklist" entry is filled out.

### DIFF
--- a/scripts/lib/startOfSession.js
+++ b/scripts/lib/startOfSession.js
@@ -1,5 +1,5 @@
 import { getSetting } from "./helpers.js";
-import { MODULE_ID } from "././module.js";
+import { MODULE_ID } from "../module.js";
 
 export function setupStartOfSession() {
   if (!game.user.isGM) return;


### PR DESCRIPTION
Fixed the following error when a journal is set for "Start of Session Checklist"

```
Uncaught (in promise) ReferenceError: MODULE_ID is not defined
[Detected 1 package: sundry(0.9.2)]
    at startOfSessionNotification (startOfSession.js:32:27)
startOfSessionNotification    @    startOfSession.js:32
await in startOfSessionNotification        
setupStartOfSession    @    startOfSession.js:6
(anonymous)    @    module.js:66
#call    @    foundry.mjs:23829
callAll    @    foundry.mjs:23788
setupGame    @    foundry.mjs:169122
```