### PR TITLE
fix: guard against null html in addGradientHelper

### DIFF
--- a/scripts/lib/messageUserColor.js
+++ b/scripts/lib/messageUserColor.js
@@ -63,7 +63,7 @@ function addGradientHelper(message, html, cssClass) {
   const colorBannerHeader = message.author.color.rgb
     .map((val) => val * 255)
     .join(", ");
-  html.style.setProperty("--player-color", colorBannerHeader);
+  html?.style?.setProperty("--player-color", colorBannerHeader);
   html?.classList?.remove(STYLE_LIST.filter((st) => st !== cssClass));
   html?.classList?.add(cssClass);
 }


### PR DESCRIPTION
## Summary

Fixes a startup error thrown by `messageUserColor` when chat messages exist but their DOM elements aren't currently rendered:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'style')
    at addGradientHelper (messageUserColor.js:66:8)
    at addGradient20Percent (messageUserColor.js:55:3)
    at setupMessageUserColor (messageUserColor.js:24:5)
```

## Cause

`setupMessageUserColor` walks `game.messages.contents` and calls `document.querySelector('.chat-message[data-message-id="..."]')` for each one. For messages whose DOM nodes aren't currently in the chat log (e.g. older messages that haven't been rendered yet), `querySelector` returns `null`, which is then passed to `addGradientHelper` as `html`.

The two `classList` calls on lines 67–68 already use optional chaining (`html?.classList?.…`), but line 66's `html.style.setProperty(...)` does not, so it throws and aborts setup.

## Fix

Apply the same `html?.style?.…` optional chaining to the `setProperty` call so the helper is consistently null-safe.

## Test plan

- [x] With `messageUserColor` set to `20-percent`, reload a world that has older chat messages outside the rendered window — no console error, setup completes.
- [x] Newly-rendered messages still receive the `--player-color` CSS variable and the appropriate gradient class via the `renderChatMessageHTML` hook.